### PR TITLE
Account name moved to separate field in discord notification

### DIFF
--- a/EsportsHelper/Rewards.py
+++ b/EsportsHelper/Rewards.py
@@ -166,6 +166,11 @@ class Rewards:
                     s.post(self.config.connectorDropsUrl, json=data)
                     time.sleep(5)
                 elif "https://discord.com/api/webhooks" in self.config.connectorDropsUrl:
+                    field0 = {
+                        "name": "Account",
+                        "value": f"{self.config.username}",
+                        "inline": True
+                    }
                     field1 = {
                         "name": "Event",
                         "value": f"{eventTitle}",
@@ -177,7 +182,7 @@ class Rewards:
                         "inline": True
                     }
                     field4 = {
-                        "name": "Unlocked-Date",
+                        "name": "Date",
                         "value": f"{unlockedDate}",
                         "inline": True
                     }
@@ -188,10 +193,9 @@ class Rewards:
                     }
                     embed = {
                         "title": "Drop!",
-                        "description": f"{self.config.username}",
                         "image": {"url": f"{productImg}"},
                         "thumbnail": {"url": f"{dropItemImg}"},
-                        "fields": [field1, field2, fieldNone, field4, fieldNone, fieldNone],
+                        "fields": [field0, field1, field2, fieldNone, field4, fieldNone, fieldNone],
                         "color": 6676471,
                         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S+08:00", time.localtime())
                     }

--- a/EsportsHelper/Rewards.py
+++ b/EsportsHelper/Rewards.py
@@ -195,7 +195,7 @@ class Rewards:
                         "title": "Drop!",
                         "image": {"url": f"{productImg}"},
                         "thumbnail": {"url": f"{dropItemImg}"},
-                        "fields": [field0, field1, field2, fieldNone, field4, fieldNone, fieldNone],
+                        "fields": [field0, field1, fieldNone, field2, field4, fieldNone, fieldNone],
                         "color": 6676471,
                         "timestamp": time.strftime("%Y-%m-%dT%H:%M:%S+08:00", time.localtime())
                     }

--- a/EsportsHelper/Utils.py
+++ b/EsportsHelper/Utils.py
@@ -96,7 +96,7 @@ englishI18n = {
         "休眠时间结束": "Waking up...",
         "进入休眠时间": "Going to sleep now...",
         "过滤失效的比赛": "Filtering out invalid matches.",
-        "总观看时长:": "Overall hours watched:",
+        "总观看时长:": "Overall hours watched: ",
         "日期:": "Date:",
         "下次检查在:": "Next check at:",
         }


### PR DESCRIPTION
A little bit unsure if _{self.config.username}_ was necessary in the _description_ in _embed_, so moved it into a separate _field0_ in notification, so it will not be shown as a line without a headline. Hope it will not break anything.