### PR TITLE
Fix SSL Certificate Verification and Redirect Handling in LiveDataProvider

### DIFF
--- a/EsportsHelper/LiveDataProvider.py
+++ b/EsportsHelper/LiveDataProvider.py
@@ -20,7 +20,7 @@ client = cloudscraper.create_scraper(
         'desktop': True
     },
     debug=False)
-client.get("https://lolesports.com/&lang=en")
+client.get("https://lolesports.com/&lang=en", allow_redirects=True)
 
 
 def fetchLeaguesId():


### PR DESCRIPTION
## Error Log

```bash
"C:\Users\admin\AppData\Local\Programs\Python\Python39\lib\ssl.py", line 1310, in do_handshake
    self._sslobj.do_handshake()
ssl.SSLCertVerificationError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "C:\Users\admin\Documents\EsportsHelper-main\main.py", line 12, in <module>
    from EsportsHelper.LiveDataProvider import fetchWatchRegions
  File "C:\Users\admin\Documents\EsportsHelper-main\EsportsHelper\LiveDataProvider.py", line 23, in <module>
    client.get("https://lolesports.com/&lang=en")
  File "C:\Users\admin\AppData\Local\Programs\Python\Python39\lib\site-packages\requests\sessions.py", line 602, in get
    return self.request("GET", url, **kwargs)
  ...
requests.exceptions.SSLError: HTTPSConnectionPool(host='lolesports.com', port=443): Max retries exceeded with url: /&lang=en (Caused by SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')))
```

## Changes Made

Updated `client.get` in `LiveDataProvider.py` to include `allow_redirects=True`.

## Notes

I live in Korea, and the issue was caused by the redirection process, which was not handled properly in the original implementation.